### PR TITLE
Add support for multi-project workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "dart-import",
-    "version": "0.1.0",
+    "version": "0.1.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "dart-import",
     "displayName": "dart-import",
     "description": "Fix Dart/Flutter's imports",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "publisher": "luanpotter",
     "repository": "https://github.com/luanpotter/vscode-dart-import",
     "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,31 +1,49 @@
 'use strict';
 
 import * as vscode from 'vscode';
+import * as path from 'path';
 
-const fetchPackageName = async (context: vscode.ExtensionContext) => {
-    const files: vscode.Uri[] = await vscode.workspace.findFiles('pubspec.yaml');
-    if (files.length !== 1) {
-        vscode.window.showErrorMessage(`Expected to find a single pubspec.yaml file, ${files.length} found.`);
+const fetchPackageInfoFor = async (activeDocumentUri: vscode.Uri) => {
+    const pubspecUris = await findPubspec(activeDocumentUri);
+    if (pubspecUris.length != 1) {
+        vscode.window.showErrorMessage(`Expected to find a single pubspec.yaml file above ${activeDocumentUri}, ${pubspecUris.length} found.`);
         return null;
     }
-    const file : vscode.TextDocument = await vscode.workspace.openTextDocument(files[0]);
-    const fileName = file.fileName.replace(/\/pubspec\.yaml$/, '');
-    const possibleNameLines = file.getText().split('\n').filter((line: String) => line.match(/^\s*name:/));
+
+    const pubspec : vscode.TextDocument = await vscode.workspace.openTextDocument(pubspecUris[0]);
+    const projectRoot = path.dirname(pubspec.fileName);
+    const possibleNameLines = pubspec.getText().split('\n').filter((line: String) => line.match(/^\s*name:/));
     if (possibleNameLines.length !== 1) {
         vscode.window.showErrorMessage(`Expected to find a single line starting with 'name:' on pubspec.yaml file, ${possibleNameLines.length} found.`);
         return null;
     }
     const nameLine = possibleNameLines[0];
-    const regex = /^\s*name:\s*(.*)$/mg.exec(nameLine);
-    if (!regex) {
+    const packageNameMatch = /^\s*name:\s*(.*)$/mg.exec(nameLine);
+    if (!packageNameMatch) {
         vscode.window.showErrorMessage(`Expected line 'name:' on pubspec.yaml to match regex, but it didn't (line: ${nameLine}).`);
         return null;
     }
     return {
-        projectRoot: fileName,
-        projectName: regex[1].trim(),
+        projectRoot: projectRoot,
+        projectName: packageNameMatch[1].trim(),
     };
 };
+
+/**
+ * Returns the set of `pubspec.yaml` files that sit above `activeFileUri` in its
+ * directory ancestry.
+ */
+const findPubspec = async (activeFileUri: vscode.Uri) => {
+    const allPubspecUris = await vscode.workspace.findFiles('pubspec.yaml');
+    return allPubspecUris.filter((pubspecUri) => {
+        const packageRootUri = pubspecUri.with({
+            path: path.dirname(pubspecUri.path),
+        });
+
+        // Containment check
+        return activeFileUri.toString().startsWith(packageRootUri.toString());
+    });
+}
 
 export const relativize = (filePath : String, importPath : String) => {
     const pathSplit = (path : String) => path.length === 0 ? [] : path.split('/');
@@ -34,7 +52,7 @@ export const relativize = (filePath : String, importPath : String) => {
     let dotdotAmount = 0, startIdx;
     for (startIdx = 0; startIdx < fileBits.length; startIdx++) {
         if (fileBits[startIdx] === importBits[startIdx]) {
-           continue; 
+           continue;
         }
         dotdotAmount = fileBits.length - startIdx;
         break;
@@ -44,14 +62,13 @@ export const relativize = (filePath : String, importPath : String) => {
 };
 
 export async function activate(context: vscode.ExtensionContext) {
-    const packageInfo = await fetchPackageName(context);
-
     const cmd = vscode.commands.registerCommand('dart-import.fix', async () => {
         const editor = vscode.window.activeTextEditor;
         if (!editor) {
             return; // No open text editor
         }
 
+        const packageInfo = await fetchPackageInfoFor(editor.document.uri);
         if (!packageInfo) {
             vscode.window.showErrorMessage('Failed to initialize extension. Is this a valid Dart/Flutter project?');
             return;


### PR DESCRIPTION
This compares the active file's URI against the set of `pubspec.yaml`s found in the project. If there is a single pubspec that exists in the active file's ancestry, the imports will be "fixed" successfully.

Fixes #3 