### PR TITLE
Added support for Windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,7 +46,15 @@ const findPubspec = async (activeFileUri: vscode.Uri) => {
 }
 
 export const relativize = (filePath : String, importPath : String) => {
-    const pathSplit = (path : String) => path.length === 0 ? [] : path.split('/');
+    const pathSplit = (_path : String) => {
+        if (_path.length === 0) return [];
+        const slash = _path.split('/');
+
+        // Handles OS specific paths (Windows related)
+        const osSeparator = _path.split(path.sep);
+        if (slash.length > osSeparator.length) return slash;
+        else return osSeparator;
+    }
     const fileBits = pathSplit(filePath);
     const importBits = pathSplit(importPath);
     let dotdotAmount = 0, startIdx;
@@ -74,8 +82,8 @@ export async function activate(context: vscode.ExtensionContext) {
             return;
         }
 
-        const currentPath = editor.document.fileName.replace(/\/[^\/]*.dart$/, '');
-        const libFolder = packageInfo.projectRoot + '/lib';
+        const currentPath = editor.document.fileName.replace(/(\/|\\)[^\/\\]*.dart$/, '');
+        const libFolder = path.join(packageInfo.projectRoot, 'lib');
         if (!currentPath.startsWith(libFolder)) {
             const l1 = 'Current file is not on project root or not on lib folder? File must be on $root/lib.';
             const l2 = `Your current file path is: '${currentPath}' and the lib folder according to the pubspec.yaml file is '${libFolder}'.`;

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -29,4 +29,11 @@ suite('#relativize test', function () {
         const result = relativize(filePath, importPath);
         assert.equal('../../sam/tom.dart', result);
     });
+
+    test('Windows - some up', function() {
+        const filePath = 'foo\\bar\\john\\carl';
+        const importPath = 'foo/bar/sam/tom.dart';
+        const result = relativize(filePath, importPath);
+        assert.equal('../../sam/tom.dart', result);
+    });
 });


### PR DESCRIPTION
This commit adds support for Windows machines.

I don't own any MacOS devices so I can't really test this out in another enviroments. So it would be nice if you could test it to check if I didn't broke something up but I don't think so because every test passes.

Also I added a test that checks the extension works with Windows paths (paths with backslashes)

