### PR TITLE
Find `pubspec.yaml` files in subdirectories

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { PackageInfo, EditorAccess, fixImports } from './main';
  * directory ancestry.
  */
 const findPubspec = async (activeFileUri: vscode.Uri) => {
-    const allPubspecUris = await vscode.workspace.findFiles('pubspec.yaml');
+    const allPubspecUris = await vscode.workspace.findFiles('**/pubspec.yaml');
     return allPubspecUris.filter((pubspecUri) => {
         const packageRootUri = pubspecUri.with({
             path: path.dirname(pubspecUri.path),


### PR DESCRIPTION
This change allows the use of [monorepos](https://en.wikipedia.org/wiki/Monorepo) where a Dart project is located within a subdirectory instead of at the root.