### PR TITLE
Support similarly prefixed workspace folders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "dart-import",
-    "version": "0.1.4",
+    "version": "0.1.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "dart-import",
     "displayName": "dart-import",
     "description": "Fix Dart/Flutter's imports",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "publisher": "luanpotter",
     "repository": "https://github.com/luanpotter/vscode-dart-import",
     "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ const findPubspec = async (activeFileUri: vscode.Uri) => {
     return allPubspecUris.filter((pubspecUri) => {
         const packageRootUri = pubspecUri.with({
             path: path.dirname(pubspecUri.path),
-        });
+        }) + '/';
 
         // Containment check
         return activeFileUri.toString().startsWith(packageRootUri.toString());


### PR DESCRIPTION
The pubspec check was matching more projects than it should have been,
when their folders shared the same prefix. For example:

foundation/
foundation_ui/

Attempting to fix imports in the foundation/ workspace folder would find
pubspecs in both both foundation/ and foundation_ui/, and the extension
would error out.

This situation was resolved by appending a / to the project folder path
before performing the pubspec search, preventing the overmatch.