### PR TITLE
Add ability to fix imports on all dart files

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "Other"
     ],
     "activationEvents": [
-        "onCommand:dart-import.fix"
+        "onCommand:dart-import.fix",
+        "onCommand:dart-import.fix-all"
     ],
     "main": "./out/extension",
     "contributes": {
@@ -20,6 +21,10 @@
             {
                 "command": "dart-import.fix",
                 "title": "Fix Imports"
+            }, 
+            {
+                "command": "dart-import.fix-all",
+                "title": "Fix All Imports"
             }
         ]
     },


### PR DESCRIPTION
Hi. 

With this pull request I'm trying to address the feature requested in #19 
The way it works it's: 

- You run `Fix All Imports` in the VsCode command palette
- The extension gets all the files opened in the current workspace inside the `lib` folder
- Iterates through every file and apply the `fixImports` function to the file
- Once it finishes fixing every file obtained, it prints the number of lines modified through all the files

This have several things that I need some help with. 

- [ ] Tests: I'm not really sure how to implement tests of multiple files being fixed in the current workspace
- [ ] Auto save: I've been struggling to find any information at all on how to auto-save a file after it has being modified through the VsCode Extension API. 
- [ ] Close active editor after saving: I think it could be a nice behaviour to close the modified editor after being saved so the user don't have to manually close all the modified editors after they have been fixed

This is also a very naive approach because I'm using the already built function `fixImports` that performs other operations that could be removed for better performance of the extension. 
If this is a problem just let me know and I'll work on it.

I'd be really happy to get some retro and see this feature implemented in the master branch of this extension because it's really helpful now that I've been using it to test it out.