### PR TITLE
Standardize the initial dots for same folder imports

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -47,16 +47,26 @@ const fixImports = async (editor: EditorAccess, packageInfo: PackageInfo, pathSe
         if (!content.startsWith('import ')) {
             break;
         }
-        const regex = new RegExp(`^\\s*import\\s*(['"])package:${packageInfo.projectName}/([^'"]*)['"]([^;]*);\\s*$`);
-        const exec = regex.exec(content);
-        if (exec) {
-            const quote = exec[1];
-            const importPath = exec[2];
-            const ending = exec[3];
+        const packageNameRegex = new RegExp(`^\\s*import\\s*(['"])package:${packageInfo.projectName}/([^'"]*)['"]([^;]*);\\s*$`);
+        const packageNameExec = packageNameRegex.exec(content);
+        if (packageNameExec) {
+            const quote = packageNameExec[1];
+            const importPath = packageNameExec[2];
+            const ending = packageNameExec[3];
             const relativeImport = relativize(relativePath, importPath, pathSep);
-            const content = `import ${quote}${relativeImport}${quote}${ending};`;
-            await editor.replaceLineAt(currentLine, content);
+            const newContent = `import ${quote}${relativeImport}${quote}${ending};`;
+            await editor.replaceLineAt(currentLine, newContent);
             count++;
+        } else {
+            const standardPrefixRegex = new RegExp('^\\s*import\\s*([\'"])\\./(.*)$');
+            const standardPrefixExec = standardPrefixRegex.exec(content);
+            if (standardPrefixExec) {
+                const quote = standardPrefixExec[1];
+                const end = standardPrefixExec[2];
+                const newContent = `import ${quote}${end}`;
+                await editor.replaceLineAt(currentLine, newContent);
+                count++;
+            }
         }
     }
     return count;

--- a/src/test/suite/fixImports.test.ts
+++ b/src/test/suite/fixImports.test.ts
@@ -51,7 +51,7 @@ suite('#fixImports test', () => {
         assert.equal('import "package:other_package/sam.dart";', editor.getLineAt(5));
     });
 
-    test('allow for use of as, show hide', async () => {
+    test('allow for use of as, show, and hide', async () => {
         const editor: EditorAccess = new FakeEditor('/lib/foo/1.dart', [
             'import "package:p/foo/2.dart" as Foo;',
             'import "package:p/foo/2.dart" show Foo;',
@@ -63,5 +63,19 @@ suite('#fixImports test', () => {
         assert.equal('import "2.dart" as Foo;', editor.getLineAt(0));
         assert.equal('import "2.dart" show Foo;', editor.getLineAt(1));
         assert.equal('import "2.dart" hide Foo;', editor.getLineAt(2));
+    });
+
+    test('standardize relative imports', async () => {
+        const editor: EditorAccess = new FakeEditor('/lib/foo/1.dart', [
+            'import "no_dot.dart";',
+            'import "./with_dot.dart" show Foo;',
+            'import "../parent.dart";',
+        ]);
+        const packageInfo: PackageInfo = { projectRoot: '', projectName: 'p' };
+        const result: number = await fixImports(editor, packageInfo, '/');
+        assert.equal(1, result);
+        assert.equal('import "no_dot.dart";', editor.getLineAt(0));
+        assert.equal('import "with_dot.dart" show Foo;', editor.getLineAt(1));
+        assert.equal('import "../parent.dart";', editor.getLineAt(2));
     });
 });


### PR DESCRIPTION
This standardizes imports with a unnecessary `./`, eg:

```dart
import './foo.dart`;
```

becomes

```dart
import `foo.dart`;
```