### PR TITLE
fix: skip file header comment in .dart file.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,9 @@ const fixImports = async (editor: EditorAccess, packageInfo: PackageInfo, pathSe
             continue;
         }
         const content = line.trim();
+        if (content.startsWith('///')) {
+            continue;
+        }
         if (!content.startsWith('import ')) {
             break;
         }


### PR DESCRIPTION
 Unable to fix the import path if there is a file header comment in .dart file such as:
```
/// This is file header comment
///
///
import 'package:xxx/yyy/z.dart'

```